### PR TITLE
added callback feature to browse output

### DIFF
--- a/autoload/tlib/cmd.vim
+++ b/autoload/tlib/cmd.vim
@@ -26,7 +26,22 @@ function! tlib#cmd#BrowseOutput(command) "{{{3
     call tlib#cmd#BrowseOutputWithCallback("tlib#cmd#DefaultBrowseOutput", a:command)
 endf
 
-" See |:TBrowseOutputWithCallback|.
+" :def: function! tlib#cmd#BrowseOutputWithCallback(callback, command)
+" Execute COMMAND and present its output in a |tlib#input#List()|;
+" when a line is selected, execute the function named as the CALLBACK
+" and pass in that line as an argument.
+"
+" The CALLBACK function gives you an opportunity to massage the COMMAND output
+" and possibly act on it in a meaningful way. For example, if COMMAND listed
+" all URIs found in the current buffer, CALLBACK could validate and then open
+" the selected URI in the system's default browser.
+"
+" This function is meant to be a tool to help compose the implementations of
+" powerful commands that use |tlib#input#List()| as a common interface. See
+" |TBrowseScriptnames| as an example.
+"
+" EXAMPLES: >
+"   call tlib#cmd#BrowseOutputWithCallback('tlib#cmd#ParseScriptname', 'scriptnames')
 function! tlib#cmd#BrowseOutputWithCallback(callback, command) "{{{3
     let list = tlib#cmd#OutputAsList(a:command)
     let cmd = tlib#input#List('s', 'Output of: '. a:command, list)

--- a/plugin/02tlib.vim
+++ b/plugin/02tlib.vim
@@ -98,8 +98,16 @@ command! -nargs=+ TKeyArg exec tlib#arg#Key([<args>])
 "   TBrowseOutput 20verb TeaseTheCulprit
 command! -nargs=1 -complete=command TBrowseOutput call tlib#cmd#BrowseOutput(<q-args>)
 
+" :display: TBrowseScriptnames
+" List all sourced script names (the output of ':scriptnames').
+"
+" When you press enter, the selected script will be opened in the current
+" window. Press ESC to cancel.
+"
+" EXAMPLES: >
 "   TBrowseScriptnames 
-command! -nargs=0 -complete=command TBrowseScriptnames call tlib#cmd#BrowseOutputWithCallback("tlib#cmd#ParseScriptname", "scriptnames")
+command! -nargs=0 -complete=command TBrowseScriptnames call
+            \ tlib#cmd#BrowseOutputWithCallback("tlib#cmd#ParseScriptname", "scriptnames")
 
 " :display: TTimeCommand CMD
 " Time the execution time of CMD.

--- a/samples/tlib/input/tlib_input_list.vim
+++ b/samples/tlib/input/tlib_input_list.vim
@@ -1,6 +1,6 @@
 " The following variable configures the way |tlib#input#ListD()| works. 
-" In this example, we allow selection multiple items (we could also 
-" allow only single choice and make |tlib#input#ListD()| work on the 
+" In this example, we allow selection of multiple items (we could also 
+" allow only a single choice and make |tlib#input#ListD()| work on the 
 " indices, not the items).
 "
 " We also set a prompt that will be displayed in the command area.


### PR DESCRIPTION
Since there may be specific operations you want to perform on the selection returned from a <code>tlib#input#List()</code>, I implemented a new function 
<code>tlib#cmd#BrowseOutputWithCallback(callback, command)</code> that executes the CALLBACK function passing the selection as an argument.

As a practical example of this new functionality, I also added a new <code>TBrowseScriptnames</code> command that allows you to select from the <code>:scriptnames</code> output and opens the selected file in the current window.

(I also reimplemented <code>tlib#cmd#BrowseOutput(command)</code> using a callback for DRYness.)

I wrote documentation for these, emulating other tlib documentation; but I wasn't able to determine how you generate the help docs from this markup (I sure would like to know! :-)

Please let me know if you would like me to make any further changes before accepting, or if you don't think this is an appropriate addition to tlib.
