### PR TITLE
Fix scratch list

### DIFF
--- a/autoload/tlib/scratch.vim
+++ b/autoload/tlib/scratch.vim
@@ -77,7 +77,7 @@ function! tlib#scratch#UseScratch(...) "{{{3
                 let cmd = 'edit'
             endif
             " TLogVAR cmd
-            silent exec 'noautocmd' cmd escape(id, '%#\ ')
+            silent exec 'noautocmd keepalt keepj' cmd escape(id, '%#\ ')
             " silent exec 'split '. id
         endif
         let ft = get(keyargs, 'scratch_filetype', '')
@@ -87,7 +87,7 @@ function! tlib#scratch#UseScratch(...) "{{{3
         endif
     endif
     setlocal buftype=nofile
-    setlocal bufhidden=hide
+    setlocal bufhidden=wipe
     setlocal noswapfile
     setlocal nobuflisted
     setlocal foldmethod=manual


### PR DESCRIPTION
Hi,
I'm using [vim-snipmate](https://github.com/garbas/vim-snipmate) that in turn 'leans' on this library. Specifically `tlib#input#List`  function is used (and maybe others).

Anyway - I noticed tlib scratch buffer does not behave nicely.
After it is used:
- alternate buffer is changed. C-^ does not work as it should, it jumps back to scratch buffer
- scratch buffer is not completely deleted. That can be seen with `:ls!` command after the buffer is used (even without 'going back' with C-^

This pull request addresses the above with:
- `setlocal bufhidden=wipe` - properly deletes buffer after it's used
- `keepalt` command preserves alternate file
- `keepj` does not mess jump list (C-o, C-i)

I learned about these from [netrw plugin error message buffer](https://github.com/vim-scripts/netrw.vim/blob/master/autoload/netrw.vim#L7837) which is very similar to scratch buffer.

Let me know what you think about the updates?
