### PR TITLE
Remove duplicate systembrowser from tags doc

### DIFF
--- a/doc/tlib.txt
+++ b/doc/tlib.txt
@@ -254,7 +254,6 @@ Contents~
         g:tlib#sys#special_suffixes ............ |g:tlib#sys#special_suffixes|
         g:tlib#sys#system_rx ................... |g:tlib#sys#system_rx|
         g:tlib#sys#system_browser .............. |g:tlib#sys#system_browser|
-        g:tlib#sys#system_browser .............. |g:tlib#sys#system_browser|
         g:tlib#sys#windows ..................... |g:tlib#sys#windows|
         g:tlib#sys#null ........................ |g:tlib#sys#null|
         tlib#sys#IsCygwinBin ................... |tlib#sys#IsCygwinBin()|
@@ -1662,10 +1661,6 @@ g:tlib#sys#special_suffixes    (default: ['xlsx\?', 'docx\?', 'pptx\?', 'accdb',
 g:tlib#sys#system_rx           (default: printf('\V\%(\^\%(%s\):\|.\%(%s\)\)', join(g:tlib#sys#special_protocols, '\|'), join(g:tlib#sys#special_suffixes, '\|')))
     Open links matching this |regexp| with |g:tlib#sys#system_browser|.
     CAVEAT: Must be a |\V| |regexp|.
-
-                                                    *g:tlib#sys#system_browser*
-g:tlib#sys#system_browser      (default: ...)
-    Open files in the system browser.
 
                                                     *g:tlib#sys#system_browser*
 g:tlib#sys#system_browser      (default: "exec 'silent !'. g:netrw_browsex_viewer shellescape('%s')")


### PR DESCRIPTION
Commit 113e12aab5c73a154921bef53459798f004ccdc6 added two lines for
system browser in the docs. This causes errors with multiple helptag
generators.

This PR fixes #20.