### PR TITLE
Fix win_id format mismatch on vim7 or bellow

### DIFF
--- a/autoload/tlib/win.vim
+++ b/autoload/tlib/win.vim
@@ -73,7 +73,11 @@ endif
 " Return vim code to jump back to the original window.
 function! tlib#win#SetById(win_id) "{{{3
     if a:win_id != g:tlib#win#null_id
-        let win_id = tlib#win#GetID()
+        if g:tlib#win#use_winid
+            let win_id = tlib#win#GetID()
+        else
+            let win_id = tlib#win#GetID().win_id
+        endif
         call tlib#win#GotoID(a:win_id)
         return printf('call tlib#win#GotoID(%s)', win_id)
         " " TLogVAR a:winnr


### PR DESCRIPTION
On vim7 or version below that do not have win_getid() and win_gotoid() support, tlib#win#GetID() return a dictionary. But in tlib#win#SetById(), win_id returned from tlib#win#GetID() is treated as a string.

This will cause error "using dictionary as string".